### PR TITLE
Adding additional identifiers for Heroic/Normal

### DIFF
--- a/LFGMM_Variables.lua
+++ b/LFGMM_Variables.lua
@@ -542,7 +542,9 @@ LFGMM_GLOBAL = {
 			"nhc[%W]*/[%W]*hc",
 			"nhc[%W]*or[%W]*hc",
 			"[.]?hc[.]?",
-			"hm"
+			"hm",
+			" h ",
+			"(h)"
 		},
 		DE = {
 			"hero[i]?[s]?[c]?[h]?"
@@ -556,7 +558,9 @@ LFGMM_GLOBAL = {
 			"non[%W]*hero[i]?[c]?",
 			"[.]?nh[c]?[.]?",
 			"normal",
-			"nm"
+			"nm",
+			" n ",
+			"(n)"
 		},
 		DE = {},
 		FR = {},


### PR DESCRIPTION
Most LFG chat have started simply using "n" or "h" in their LFG string, so many posts were not getting picked up, or more frequently, heroics were getting picked up when they should not have been.  Adding these 4 entries pretty much fixed all of the messages I was seeing in chat.